### PR TITLE
Add Click Event for Routing

### DIFF
--- a/src/__tests__/Home.test.tsx
+++ b/src/__tests__/Home.test.tsx
@@ -4,8 +4,34 @@ import mockData from "../../public/scratch/season_standings.json";
 
 import Home from "@/app/page";
 
+jest.mock("next/navigation", () => {
+  return {
+    useRouter: () => ({
+      push: jest.fn(),
+      replace: jest.fn(),
+      refresh: jest.fn(),
+      back: jest.fn(),
+      forward: jest.fn(),
+      prefetch: jest.fn(),
+    }),
+    usePathname: () => "/",
+    useSearchParams: () => ({
+      get: jest.fn(),
+    }),
+  };
+});
+
 beforeEach(() => {
-  global.fetch = jest.fn(() => Promise.resolve(mockData));
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          data: mockData,
+        }),
+    })
+  ) as jest.Mock;
 });
 
 afterEach(() => {

--- a/src/app/components/StandingsTable.tsx
+++ b/src/app/components/StandingsTable.tsx
@@ -1,6 +1,21 @@
+import { useRouter } from "next/navigation";
+
 export default function StandingsTable(props) {
   const headers = props.headers;
   const rowData = props.rowData;
+
+  const router = useRouter();
+
+  const handleClick = (teamName: string) => {
+    console.log(teamName);
+    console.log(slugify(teamName));
+
+    router.push(`/scoring_leaders/${slugify(teamName)}`);
+  };
+
+  const slugify = (text: string) => {
+    return text.replace(/\s+/g, "_");
+  };
 
   return (
     <table className='text-center'>
@@ -18,11 +33,12 @@ export default function StandingsTable(props) {
         {rowData.map((item, index) => (
           <tr
             key={index}
-            className={
+            onClick={() => handleClick(item.team.name)}
+            className={`${
               index % 2 === 0
                 ? "bg-[rgba(141,153,174,0.88)]"
                 : "bg-[rgba(224, 232, 235, 0.88)]"
-            }
+            } hover:bg-[rgba(180,200,220,0.88)] cursor-pointer`}
           >
             <td>{item.position}</td>
             <td>{item.team.name}</td>

--- a/src/app/components/StandingsTable.tsx
+++ b/src/app/components/StandingsTable.tsx
@@ -7,9 +7,6 @@ export default function StandingsTable(props) {
   const router = useRouter();
 
   const handleClick = (teamName: string) => {
-    console.log(teamName);
-    console.log(slugify(teamName));
-
     router.push(`/scoring_leaders/${slugify(teamName)}`);
   };
 
@@ -22,7 +19,6 @@ export default function StandingsTable(props) {
       <thead className='bg-[#2b2d42]'>
         <tr>
           {headers.map((header) => (
-            // eslint-disable-next-line react/jsx-key
             <th key={header.field} className='mx-3 min-w-[90px]'>
               {header.field}
             </th>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,13 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <div className="bg-[url('/background_images/soccer_pitch.jpg')] bg-cover bg-center">
+          <main>
+            <div className='h-screen flex flex-col justify-center items-center -translate-y-3'>
+              {children}
+            </div>
+          </main>
+        </div>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,10 +43,11 @@ export default function Home() {
     fetchData();
   }, []);
   return (
-    <main>
-      <div className="h-screen flex justify-center items-center bg-[url('/background_images/soccer_pitch.jpg')] bg-cover bg-center">
-        {!loading && <StandingsTable headers={colNames} rowData={rowData} />}
-      </div>
-    </main>
+    <div className='h-screen flex flex-col justify-center items-center'>
+      <h1 className='text-5xl mb-4 drop-shadow-[0_2px_4px_rgba(0,0,0,0.7)]'>
+        Premier League Table
+      </h1>
+      {!loading && <StandingsTable headers={colNames} rowData={rowData} />}
+    </div>
   );
 }

--- a/src/app/scoring_leaders/[team_name]/components/ScoringTable.tsx
+++ b/src/app/scoring_leaders/[team_name]/components/ScoringTable.tsx
@@ -1,0 +1,43 @@
+export default function StandingsTable(props) {
+  const headers = props.headers;
+  const rowData = props.rowData;
+
+  return (
+    <table className='text-center'>
+      <thead className='bg-[#2b2d42]'>
+        <tr>
+          {headers.map((header) => (
+            // eslint-disable-next-line react/jsx-key
+            <th key={header.field} className='mx-3 min-w-[90px]'>
+              {header.field}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody className='bg-[rgba(141,153,174,0.88)]'>
+        {rowData.map((item, index) => (
+          <tr
+            key={index}
+            onClick={() => handleClick(item.team.name)}
+            className={`${
+              index % 2 === 0
+                ? "bg-[rgba(141,153,174,0.88)]"
+                : "bg-[rgba(224, 232, 235, 0.88)]"
+            } hover:bg-[rgba(180,200,220,0.88)] cursor-pointer`}
+          >
+            <td>{item.position}</td>
+            <td>{item.team.name}</td>
+            <td>{item.playedGames}</td>
+            <td>{item.won}</td>
+            <td>{item.draw}</td>
+            <td>{item.lost}</td>
+            <td>{item.goalsFor}</td>
+            <td>{item.goalsAgainst}</td>
+            <td>{item.goalDifference}</td>
+            <td>{item.points}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/app/scoring_leaders/[team_name]/components/ScoringTable.tsx
+++ b/src/app/scoring_leaders/[team_name]/components/ScoringTable.tsx
@@ -7,7 +7,6 @@ export default function StandingsTable(props) {
       <thead className='bg-[#2b2d42]'>
         <tr>
           {headers.map((header) => (
-            // eslint-disable-next-line react/jsx-key
             <th key={header.field} className='mx-3 min-w-[90px]'>
               {header.field}
             </th>
@@ -18,7 +17,6 @@ export default function StandingsTable(props) {
         {rowData.map((item, index) => (
           <tr
             key={index}
-            onClick={() => handleClick(item.team.name)}
             className={`${
               index % 2 === 0
                 ? "bg-[rgba(141,153,174,0.88)]"

--- a/src/app/scoring_leaders/[team_name]/page.tsx
+++ b/src/app/scoring_leaders/[team_name]/page.tsx
@@ -1,9 +1,36 @@
 "use client";
 
 import { useParams } from "next/navigation";
+import ScoringTable from "./components/ScoringTable";
 
 export default function ScoringLeaders() {
   const { team_name } = useParams();
+
+  const colNames = [
+    { field: "Position" },
+    { field: "Name" },
+    { field: "Played Games" },
+    { field: "Won" },
+    { field: "Draw" },
+    { field: "Lost" },
+    { field: "Goals For" },
+    { field: "Goals Against" },
+    { field: "+ -" },
+    { field: "Points" },
+  ];
+
+  const blankRows = Array.from({ length: 10 }, (_, i) => ({
+    Position: i + 1,
+    team: { name: "" },
+    "Played Games": "",
+    Won: "",
+    Draw: "",
+    Lost: "",
+    "Goals For": "",
+    "Goals Against": "",
+    "+ -": "",
+    Points: "",
+  }));
 
   const deslugify = (slug: string | string[]): string => {
     let singleSlug;
@@ -21,7 +48,6 @@ export default function ScoringLeaders() {
 
   const desluggedTeam = deslugify(team_name);
 
-  console.log(deslugify(team_name));
   return (
     <div className='text-5xl mb-4 drop-shadow-[0_2px_4px_rgba(0,0,0,0.7)] text-center'>
       <h1>{desluggedTeam}</h1>

--- a/src/app/scoring_leaders/[team_name]/page.tsx
+++ b/src/app/scoring_leaders/[team_name]/page.tsx
@@ -1,36 +1,9 @@
 "use client";
 
 import { useParams } from "next/navigation";
-import ScoringTable from "./components/ScoringTable";
 
 export default function ScoringLeaders() {
   const { team_name } = useParams();
-
-  const colNames = [
-    { field: "Position" },
-    { field: "Name" },
-    { field: "Played Games" },
-    { field: "Won" },
-    { field: "Draw" },
-    { field: "Lost" },
-    { field: "Goals For" },
-    { field: "Goals Against" },
-    { field: "+ -" },
-    { field: "Points" },
-  ];
-
-  const blankRows = Array.from({ length: 10 }, (_, i) => ({
-    Position: i + 1,
-    team: { name: "" },
-    "Played Games": "",
-    Won: "",
-    Draw: "",
-    Lost: "",
-    "Goals For": "",
-    "Goals Against": "",
-    "+ -": "",
-    Points: "",
-  }));
 
   const deslugify = (slug: string | string[]): string => {
     let singleSlug;

--- a/src/app/scoring_leaders/[team_name]/page.tsx
+++ b/src/app/scoring_leaders/[team_name]/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+export default function ScoringLeaders() {
+  const { team_name } = useParams();
+
+  const deslugify = (slug: string | string[]): string => {
+    let singleSlug;
+
+    if (Array.isArray(slug)) {
+      singleSlug = slug.join(", ");
+    } else {
+      singleSlug = slug;
+    }
+
+    singleSlug = singleSlug.replace(/_/g, " ");
+
+    return singleSlug;
+  };
+
+  const desluggedTeam = deslugify(team_name);
+
+  console.log(deslugify(team_name));
+  return (
+    <div className='text-5xl mb-4 drop-shadow-[0_2px_4px_rgba(0,0,0,0.7)] text-center'>
+      <h1>{desluggedTeam}</h1>
+      <h2>In Top 100</h2>
+    </div>
+  );
+}


### PR DESCRIPTION
This will allow for the standings table to be clickable and reroute to the team scoring page. The scoring page currently only displays the team title. 